### PR TITLE
Fix build on ghc 7.8

### DIFF
--- a/hackage-security.cabal
+++ b/hackage-security.cabal
@@ -11,8 +11,8 @@ category:            Distribution
 build-type:          Simple
 cabal-version:       >=1.10
 
-flag base46
-  description: Are we using base 4.6 or higher?
+flag base48
+  description: Are we using base 4.8 or higher?
   manual: False
 
 library
@@ -99,8 +99,8 @@ library
   -- TODO: We should get rid of the -fno-warn-deprecated-flags here
   ghc-options:         -Wall -fno-warn-deprecated-flags
 
-  if flag(base46)
-    build-depends: base >= 4.6
+  if flag(base48)
+    build-depends: base >= 4.8
   else
     build-depends: old-locale >= 1.0
 

--- a/secure-local/Prelude.hs
+++ b/secure-local/Prelude.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE CPP #-}
 module Prelude (
     module P
-#if !MIN_VERSION_base(4,6,0)
+#if !MIN_VERSION_base(4,8,0)
   , Applicative(..)
   , Monoid(..)
   , (<$>)
@@ -13,7 +13,7 @@ module Prelude (
 #endif
   ) where
 
-#if MIN_VERSION_base(4,6,0)
+#if MIN_VERSION_base(4,8,0)
 import "base" Prelude as P
 #else
 import "base" Prelude as P

--- a/src/Hackage/Security/JSON.hs
+++ b/src/Hackage/Security/JSON.hs
@@ -24,7 +24,7 @@ import Text.JSON.Canonical
 import Network.URI
 import qualified Data.Map as Map
 
-#if !MIN_VERSION_base(4,6,0)
+#if !MIN_VERSION_base(4,8,0)
 import System.Locale
 #endif
 
@@ -119,7 +119,7 @@ instance ReportSchemaErrors m => FromJSON m UTCTime where
     case parseTimeM False defaultTimeLocale "%FT%TZ" str of
       Just time -> return time
       Nothing   -> expected "valid date-time string" (Just str)
-#if !MIN_VERSION_base(4,6,0)
+#if !MIN_VERSION_base(4,8,0)
     where
       parseTimeM _trim = parseTime
 #endif

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE CPP #-}
 module Prelude (
     module P
-#if !MIN_VERSION_base(4,6,0)
+#if !MIN_VERSION_base(4,8,0)
   , Applicative(..)
   , Monoid(..)
   , (<$>)
@@ -13,7 +13,7 @@ module Prelude (
 #endif
   ) where
 
-#if MIN_VERSION_base(4,6,0)
+#if MIN_VERSION_base(4,8,0)
 import "base" Prelude as P
 #else
 import "base" Prelude as P hiding (catch)


### PR DESCRIPTION
Change base version for 7.10 prelude changes from 4.6 to 4.8. Otherwise
building on 7.8 fails because Applicative, Monoid and so on are missing.