### PR TITLE
Travis, stack.yaml, and relaxed internal upper bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tags
 prototype-state/client/
 prototype-state/server/
 prototype-state/offline/
+.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# The different configurations we want to test. You could also do things like
+# change flags or use --stack-yaml to point to a different file.
+env:
+- ARGS=""
+- ARGS="--resolver lts-3"
+- ARGS="--resolver lts"
+- ARGS="--resolver nightly"
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.4.0/stack-0.1.4.0-x86_64-linux.tar.gz | tar xz -C ~/.local/bin
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script: stack $ARGS --no-terminal --install-ghc test --haddock
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/hackage-repo-tool/hackage-repo-tool.cabal
+++ b/hackage-repo-tool/hackage-repo-tool.cabal
@@ -40,7 +40,7 @@ executable hackage-repo-tool
                        time                 >= 1.2  && < 1.6,
                        unix                 >= 2.5  && < 2.8,
                        zlib                 >= 0.5  && < 0.7,
-                       hackage-security     >= 0.2  && < 0.4
+                       hackage-security     >= 0.2  && < 0.5
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  DeriveDataTypeable

--- a/hackage-root-tool/hackage-root-tool.cabal
+++ b/hackage-root-tool/hackage-root-tool.cabal
@@ -28,7 +28,7 @@ executable hackage-root-tool
   build-depends:       base                 >= 4.4  && < 5,
                        filepath             >= 1.2  && < 1.5,
                        optparse-applicative >= 0.11 && < 0.12,
-                       hackage-security     >= 0.2  && < 0.4
+                       hackage-security     >= 0.2  && < 0.5
   default-language:    Haskell2010
   other-extensions:    CPP, ScopedTypeVariables, RecordWildCards
   ghc-options:         -Wall

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,13 @@
+resolver: lts-3.4
+packages:
+- hackage-security
+- precompute-fileinfo
+- hackage-security-http-client
+- example-client
+- hackage-security-curl
+- hackage-root-tool
+- hackage-repo-tool
+- hackage-security-HTTP
+extra-deps:
+- ed25519-0.0.2.0
+- zlib-0.6.1.1


### PR DESCRIPTION
You can check builds at:

https://travis-ci.org/snoyberg/hackage-security

Please wait to merge until after that build succeeds.

The well-typed org repo will still need to have Travis enabled. Once that's done, I'd recommend adding a Travis badge to the README.