### PR TITLE
Allow building with Cabal 1.25.

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -95,7 +95,7 @@ library
   build-depends:       base              >= 4.5     && < 5,
                        base64-bytestring >= 1.0     && < 1.1,
                        bytestring        >= 0.9     && < 0.11,
-                       Cabal             >= 1.14    && < 1.25,
+                       Cabal             >= 1.14    && < 1.26,
                        containers        >= 0.4     && < 0.6,
                        directory         >= 1.1.0.2 && < 1.3,
                        ed25519           >= 0.0     && < 0.1,


### PR DESCRIPTION
Would be also nice if the dependency was bumped on Hackage. This shouldn't affect any normal clients, since odd Cabal versions signify development snapshots.