### PR TITLE
Fix breakage introduced by 9b6adacb98a363708c1dd4e517ef6fc420fea8a0

### DIFF
--- a/hackage-security/src/Hackage/Security/Key.hs
+++ b/hackage-security/src/Hackage/Security/Key.hs
@@ -32,6 +32,7 @@ import Text.JSON.Canonical
 import qualified Crypto.Hash.SHA256   as SHA256
 import qualified Crypto.Sign.Ed25519  as Ed25519
 import qualified Data.ByteString      as BS
+import qualified Data.ByteString.Char8 as BS.C8
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as BS.L
 
@@ -160,7 +161,7 @@ class HasKeyId key where
 
 instance HasKeyId PublicKey where
   keyId = KeyId
-        . show
+        . BS.C8.unpack
         . Base16.encode
         . SHA256.hashlazy
         . renderCanonicalJSON

--- a/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
+++ b/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
@@ -18,6 +18,7 @@ import qualified Crypto.Hash.SHA256   as SHA256
 import qualified Data.Map             as Map
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as BS.L
+import qualified Data.ByteString.Char8 as BS.C8
 
 import Hackage.Security.JSON
 import Hackage.Security.TUF.Common
@@ -59,7 +60,7 @@ fileInfo :: BS.L.ByteString -> FileInfo
 fileInfo bs = FileInfo {
       fileInfoLength = FileLength . fromIntegral $ BS.L.length bs
     , fileInfoHashes = Map.fromList [
-          (HashFnSHA256, Hash $ show $ Base16.encode $ SHA256.hashlazy bs)
+          (HashFnSHA256, Hash $ BS.C8.unpack $ Base16.encode $ SHA256.hashlazy bs)
         ]
     }
 


### PR DESCRIPTION
The previous code used

    show (CH.hashlazy bs :: CH.Digest CH.SHA256))

but contrary to my assumption, the `Show` instance for `Digest` results in an
unquoted `String`. So when switching to the non-overloaded API, we need to use
ByteString's `unpack` rather than `show` to convert to a `String`