### PR TITLE
Fix corrupt local 00-index.tar

### DIFF
--- a/hackage-security/hackage-security.cabal
+++ b/hackage-security/hackage-security.cabal
@@ -46,6 +46,11 @@ flag use-network-uri
   description: Are we using network-uri?
   manual: False
 
+Flag old-directory
+  description: Use directory < 1.2 and old-time
+  manual:      False
+  default:     False
+
 library
   -- Most functionality is exported through the top-level entry points .Client
   -- and .Server; the other exported modules are intended for qualified imports.
@@ -113,6 +118,10 @@ library
                        -- whatever versions are bundled with ghc:
                        template-haskell,
                        ghc-prim
+  if flag(old-directory)
+    build-depends:     directory <  1.2, old-time >= 1 && < 1.2
+  else
+    build-depends:     directory >= 1.2
   hs-source-dirs:      src
   default-language:    Haskell2010
   default-extensions:  DefaultSignatures

--- a/hackage-security/src/Hackage/Security/Util/Path.hs
+++ b/hackage-security/src/Hackage/Security/Util/Path.hs
@@ -85,7 +85,11 @@ import Control.Monad
 import Data.List (isPrefixOf)
 import System.IO (IOMode(..), BufferMode(..), Handle, SeekMode(..))
 import System.IO.Unsafe (unsafeInterleaveIO)
+#if MIN_VERSION_directory(1,2,0)
 import Data.Time (UTCTime)
+#else
+import System.Time (ClockTime)
+#endif
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Lazy    as BS.L
 import qualified System.FilePath         as FP
@@ -333,7 +337,11 @@ doesDirectoryExist path = do
     filePath <- toAbsoluteFilePath path
     Dir.doesDirectoryExist filePath
 
+#if MIN_VERSION_directory(1,2,0)
 getModificationTime :: FsRoot root => Path root -> IO UTCTime
+#else
+getModificationTime :: FsRoot root => Path root -> IO ClockTime
+#endif
 getModificationTime path = do
     filePath <- toAbsoluteFilePath path
     Dir.getModificationTime filePath

--- a/hackage-security/src/Hackage/Security/Util/Path.hs
+++ b/hackage-security/src/Hackage/Security/Util/Path.hs
@@ -53,6 +53,7 @@ module Hackage.Security.Util.Path (
   , removeDirectory
   , doesFileExist
   , doesDirectoryExist
+  , getModificationTime
   , removeFile
   , getTemporaryDirectory
   , getDirectoryContents
@@ -84,6 +85,7 @@ import Control.Monad
 import Data.List (isPrefixOf)
 import System.IO (IOMode(..), BufferMode(..), Handle, SeekMode(..))
 import System.IO.Unsafe (unsafeInterleaveIO)
+import Data.Time (UTCTime)
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Lazy    as BS.L
 import qualified System.FilePath         as FP
@@ -330,6 +332,11 @@ doesDirectoryExist :: FsRoot root => Path root -> IO Bool
 doesDirectoryExist path = do
     filePath <- toAbsoluteFilePath path
     Dir.doesDirectoryExist filePath
+
+getModificationTime :: FsRoot root => Path root -> IO UTCTime
+getModificationTime path = do
+    filePath <- toAbsoluteFilePath path
+    Dir.getModificationTime filePath
 
 removeFile :: FsRoot root => Path root -> IO ()
 removeFile path = do


### PR DESCRIPTION
Doing cabal update with non-secure and secure modes corrupts the 00-index.tar since they both write to it and in secure mode it does an incremental update and doesn't check whether the existing 00-index.tar is valid before extending it. (This isn't a security issue since the 00-index.tar.gz was verified).

This patch uses a simple heuristic which is to use the mtime of the 00-index.tar.idx. More sophisticated methods are possible. We could read the expected offset out of the 00-index.tar.idx and check this is right. Or we could read the 00-index.tar and compare it with the expected uncompressed data. This patch may well be enough in practice however.