### PR TITLE
Extend 'HashFn' to support MD5 and be truly extensible (v2)

### DIFF
--- a/hackage-security/src/Hackage/Security/Key.hs
+++ b/hackage-security/src/Hackage/Security/Key.hs
@@ -153,7 +153,7 @@ instance Monad m => ToObjectKey m KeyId where
   toObjectKey = return . keyIdString
 
 instance Monad m => FromObjectKey m KeyId where
-  fromObjectKey = return . KeyId
+  fromObjectKey = return . Just . KeyId
 
 -- | Compute the key ID of a key
 class HasKeyId key where

--- a/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
+++ b/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
@@ -29,6 +29,7 @@ import Hackage.Security.Util.Path
 -------------------------------------------------------------------------------}
 
 data HashFn = HashFnSHA256
+            | HashFnMD5
   deriving (Show, Eq, Ord)
 
 -- | File information
@@ -87,9 +88,11 @@ fileInfoSHA256 FileInfo{..} = Map.lookup HashFnSHA256 fileInfoHashes
 
 instance Monad m => ToObjectKey m HashFn where
   toObjectKey HashFnSHA256 = return "sha256"
+  toObjectKey HashFnMD5    = return "md5"
 
 instance ReportSchemaErrors m => FromObjectKey m HashFn where
   fromObjectKey "sha256" = return (Just HashFnSHA256)
+  fromObjectKey "md5"    = return (Just HashFnMD5)
   fromObjectKey _        = return Nothing
 
 instance Monad m => ToJSON m FileInfo where

--- a/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
+++ b/hackage-security/src/Hackage/Security/TUF/FileInfo.hs
@@ -89,8 +89,8 @@ instance Monad m => ToObjectKey m HashFn where
   toObjectKey HashFnSHA256 = return "sha256"
 
 instance ReportSchemaErrors m => FromObjectKey m HashFn where
-  fromObjectKey "sha256" = return HashFnSHA256
-  fromObjectKey str      = expected "valid hash function" (Just str)
+  fromObjectKey "sha256" = return (Just HashFnSHA256)
+  fromObjectKey _        = return Nothing
 
 instance Monad m => ToJSON m FileInfo where
   toJSON FileInfo{..} = mkObject [

--- a/hackage-security/src/Hackage/Security/TUF/FileMap.hs
+++ b/hackage-security/src/Hackage/Security/TUF/FileMap.hs
@@ -127,8 +127,7 @@ instance Monad m => ToObjectKey m TargetPath where
 
 instance ReportSchemaErrors m => FromObjectKey m TargetPath where
   fromObjectKey ('<':'r':'e':'p':'o':'>':'/':path) =
-    return . TargetPathRepo  . rootPath . fromUnrootedFilePath $ path
+    return . Just . TargetPathRepo  . rootPath . fromUnrootedFilePath $ path
   fromObjectKey ('<':'i':'n':'d':'e':'x':'>':'/':path) =
-    return . TargetPathIndex . rootPath . fromUnrootedFilePath $ path
-  fromObjectKey str =
-    expected "target path" (Just str)
+    return . Just . TargetPathIndex . rootPath . fromUnrootedFilePath $ path
+  fromObjectKey _str = return Nothing


### PR DESCRIPTION
Based on #161 but taking a different approach to ignoring unexpected object keys.

The library generally handles JSON in an extensible way by only selecting out the parts that it expects, so other object fields are ignored. In particular the library only constructs a representation for the parts it expects, rather than holding all the "other" parts. So we do not expect a full round trip, we expect to loose the stuff we were not expecting.

So this approach does the same thing with unknown Map keys, we consistently ignore them.

Then on top of that we also add support for the name of the MD5 hash function (no support for generating or using them, just representing them in file info).