### PR TITLE
In file content verification, ignore md5 hashes

### DIFF
--- a/hackage-security/src/Hackage/Security/Client/Repository/Local.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Local.hs
@@ -92,8 +92,6 @@ verifyLocalFile :: LocalFile typ -> Trusted FileInfo -> IO Bool
 verifyLocalFile (LocalFile fp) trustedInfo = do
     -- Verify the file size before comparing the entire file info
     sz <- FileLength <$> getFileSize fp
-    if sz /= fileInfoLength
+    if sz /= fileInfoLength (trusted trustedInfo)
       then return False
-      else knownFileInfoEqual info <$> computeFileInfo fp
-  where
-    info@FileInfo{..} = trusted trustedInfo
+      else compareTrustedFileInfo (trusted trustedInfo) <$> computeFileInfo fp

--- a/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
+++ b/hackage-security/src/Hackage/Security/Client/Repository/Remote.hs
@@ -652,9 +652,10 @@ instance DownloadedFile RemoteTemp where
 verifyRemoteFile :: RemoteTemp typ -> Trusted FileInfo -> IO Bool
 verifyRemoteFile remoteTemp trustedInfo = do
     sz <- FileLength <$> remoteSize remoteTemp
-    if sz /= fileInfoLength
+    if sz /= fileInfoLength (trusted trustedInfo)
       then return False
-      else withRemoteBS remoteTemp $ knownFileInfoEqual info . fileInfo
+      else withRemoteBS remoteTemp $
+             compareTrustedFileInfo (trusted trustedInfo) . fileInfo
   where
     remoteSize :: RemoteTemp typ -> IO Int54
     remoteSize DownloadedWhole{..} = getFileSize wholeTemp
@@ -678,8 +679,6 @@ verifyRemoteFile remoteTemp trustedInfo = do
                 BS.L.take (fromIntegral deltaSeek) existing
               , temp
               ]
-
-    info@FileInfo{..} = trusted trustedInfo
 
 {-------------------------------------------------------------------------------
   Auxiliary: multiple exit points


### PR DESCRIPTION
The file content verification works by taking the known trusted file
info that we expect (from the TUF metadata files) and the actual file
info from computing the hashes of the target file and simply comparing
them. The file info contains a Map HashFn Hash, ie an entry for multiple
hash function algorithms. So the problem is that if the TUF metadata
contained both md5 and sha256 hashes but we only computed the sha256 of
the target file then these two maps to not compare equal.

So now the code has a clearer explicit policy on which hash functions we
will check and which ones we will allow but ignore. Currently that
policy is that we check sha256 and ignore md5.