### PR TITLE
Fix some GHC 8 warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ prototype-state/client/
 prototype-state/server/
 prototype-state/offline/
 .stack-work/
+dist-newstyle

--- a/hackage-security/src/Hackage/Security/Client.hs
+++ b/hackage-security/src/Hackage/Security/Client.hs
@@ -332,7 +332,13 @@ cachedVersion CachedInfo{..} remoteFile =
       DontCache  -> Nothing
 
 -- | Get all cached info (if any)
-getCachedInfo :: (Applicative m, MonadIO m) => Repository down -> m CachedInfo
+getCachedInfo ::
+#if __GLASGOW_HASKELL__ < 800
+                 (Applicative m, MonadIO m)
+#else
+                 MonadIO m
+#endif
+              => Repository down -> m CachedInfo
 getCachedInfo rep = do
     (cachedRoot, cachedKeyEnv) <- readLocalRoot rep
     cachedTimestamp <- readLocalFile rep cachedKeyEnv CachedTimestamp
@@ -353,8 +359,10 @@ readLocalRoot rep = do
                     readCachedJSON rep KeyEnv.empty cachedPath
     return (trustLocalFile signedRoot, rootKeys (signed signedRoot))
 
-readLocalFile :: ( FromJSON ReadJSON_Keys_Layout (Signed a)
-                 , MonadIO m, Applicative m
+readLocalFile :: ( FromJSON ReadJSON_Keys_Layout (Signed a), MonadIO m
+#if __GLASGOW_HASKELL__ < 800
+                 , Applicative m
+#endif
                  )
               => Repository down -> KeyEnv -> CachedFile -> m (Maybe (Trusted a))
 readLocalFile rep cachedKeyEnv file = do

--- a/hackage-security/src/Hackage/Security/Client/Formats.hs
+++ b/hackage-security/src/Hackage/Security/Client/Formats.hs
@@ -113,4 +113,3 @@ formatsLookup (HFZ FGz) (FsGz     a) = a
 formatsLookup (HFS hf)  (FsUn   _  ) = hasFormatAbsurd hf
 formatsLookup (HFS hf)  (FsGz     _) = hasFormatAbsurd hf
 formatsLookup (HFS hf)  (FsUnGz _ a) = formatsLookup hf (FsGz a)
-formatsLookup _         _            = error "inaccessible"


### PR DESCRIPTION
Re: last patch, I can use CPP there as well to make it warning-free on older GHCs.